### PR TITLE
feat: add animated soul circle chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # soulcircle
-a circle with soul
+
+A breathing rainbow circle that chats with you.
+
+## Usage
+
+1. Open `index.html` in a modern browser.
+2. Click the rainbow circle and enter your OpenAI API key when prompted.
+3. The circle will ask questions based on your current time and location.
+4. Continue the conversation through the bubble chat interface.
+
+No data is stored; the dialogue only lives in your session.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Soul Circle</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="background"></div>
+  <div id="circle-wrapper">
+    <div id="breathing-circle"></div>
+  </div>
+  <div id="chat" class="hidden">
+    <div id="messages"></div>
+    <form id="input-form">
+      <input id="message-input" type="text" placeholder="输入你的想法..." autocomplete="off" />
+      <button type="submit">发送</button>
+    </form>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "soulcircle",
+  "version": "1.0.0",
+  "description": "Breathing rainbow circle AI chat",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,79 @@
+const circleWrapper = document.getElementById('circle-wrapper');
+const chat = document.getElementById('chat');
+const messagesEl = document.getElementById('messages');
+const form = document.getElementById('input-form');
+const input = document.getElementById('message-input');
+
+let apiKey = '';
+let started = false;
+let userLocation = '未知地点';
+let conversation = [];
+
+if (navigator.geolocation) {
+  navigator.geolocation.getCurrentPosition(pos => {
+    userLocation = `${pos.coords.latitude.toFixed(2)}, ${pos.coords.longitude.toFixed(2)}`;
+  });
+}
+
+function addMessage(sender, text) {
+  const msg = document.createElement('div');
+  msg.className = `message ${sender}`;
+  msg.textContent = text;
+  messagesEl.appendChild(msg);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+circleWrapper.addEventListener('click', async () => {
+  if (started) return;
+  apiKey = prompt('请输入您的 OpenAI API 密钥');
+  if (!apiKey) return;
+  started = true;
+  chat.classList.remove('hidden');
+  await askFirstQuestion();
+});
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  input.value = '';
+  addMessage('user', text);
+  conversation.push({ role: 'user', content: text });
+  const reply = await fetchAI(conversation);
+  addMessage('assistant', reply);
+  conversation.push({ role: 'assistant', content: reply });
+});
+
+async function askFirstQuestion() {
+  const time = new Date().toLocaleString();
+  conversation = [
+    {
+      role: 'system',
+      content:
+        '你是一个治愈系的智慧生命体，化身为一只呼吸的圆圈。你会用温柔、简短的中文与用户交谈。'
+    },
+    {
+      role: 'user',
+      content: `现在时间是${time}，我位于${userLocation}。请问我一个能够更了解我的问题。`
+    }
+  ];
+  const question = await fetchAI(conversation);
+  addMessage('assistant', question);
+  conversation.push({ role: 'assistant', content: question });
+}
+
+async function fetchAI(messages) {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages
+    })
+  });
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() || '（没有收到回复）';
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,138 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #fff;
+}
+
+.background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(circle at 50% 50%, #00111a, #000);
+  overflow: hidden;
+}
+
+.background::before {
+  content: '';
+  position: absolute;
+  width: 200%;
+  height: 200%;
+  top: -50%;
+  left: -50%;
+  background: radial-gradient(circle at 30% 30%, rgba(0, 150, 255, 0.25), transparent 60%),
+              radial-gradient(circle at 70% 70%, rgba(0, 255, 150, 0.25), transparent 60%),
+              radial-gradient(circle at 20% 80%, rgba(255, 0, 200, 0.25), transparent 60%);
+  animation: drift 30s linear infinite;
+  filter: blur(80px);
+}
+
+@keyframes drift {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+#circle-wrapper {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 150px;
+  height: 150px;
+  transform: translate(-50%, -50%);
+  animation: spin 20s linear infinite;
+}
+
+#breathing-circle {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(red, orange, yellow, green, cyan, blue, violet, red);
+  animation: breathe 4s ease-in-out infinite;
+  box-shadow: 0 0 40px rgba(255, 255, 255, 0.6);
+}
+
+@keyframes breathe {
+  0%, 100% { transform: scale(0.9); }
+  50% { transform: scale(1.1); }
+}
+
+@keyframes spin {
+  from { transform: translate(-50%, -50%) rotate(0deg); }
+  to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+#chat {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+#messages {
+  width: 100%;
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.message {
+  max-width: 70%;
+  padding: 10px 15px;
+  border-radius: 20px;
+  line-height: 1.4;
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
+.message.user {
+  align-self: flex-end;
+  background: rgba(0, 150, 200, 0.4);
+}
+
+.message.assistant {
+  align-self: flex-start;
+  background: rgba(50, 50, 150, 0.4);
+}
+
+#input-form {
+  width: 100%;
+  display: flex;
+  gap: 10px;
+}
+
+#message-input {
+  flex: 1;
+  padding: 10px;
+  border-radius: 20px;
+  border: none;
+  outline: none;
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+#input-form button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 20px;
+  background: rgba(0, 200, 150, 0.6);
+  color: #fff;
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- create responsive page with a breathing rainbow circle in a drifting deep-sea backdrop
- enable bubble chat that asks AI-generated questions using current time and location
- document usage and add placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98ee577c48328af07d7f89b9dc2f3