### PR TITLE
feat: add settings and interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A breathing rainbow circle that chats with you.
 ## Usage
 
 1. Open `index.html` in a modern browser.
-2. Click the rainbow circle and enter your OpenAI API key when prompted.
-3. The circle will ask questions based on your current time and location.
-4. Continue the conversation through the bubble chat interface.
-
-No data is stored; the dialogue only lives in your session.
+2. 点击右上角的设置按钮，选择模型并填写对应的 API Key（OpenAI 或 DeepSeek）。
+3. 双击圆圈开始呼吸并提出问题，单击圆圈则震动并预测你的行为。
+4. 在下方气泡中继续对话。所有对话都会保存在本地，可以在设置中清除。

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="settings-button">⚙️</button>
   <div class="background"></div>
   <div id="circle-wrapper">
     <div id="breathing-circle"></div>
@@ -17,6 +18,25 @@
       <input id="message-input" type="text" placeholder="输入你的想法..." autocomplete="off" />
       <button type="submit">发送</button>
     </form>
+  </div>
+  <div id="settings-modal" class="hidden">
+    <div class="modal-content">
+      <h2>模型设置</h2>
+      <label>
+        选择模型：
+        <select id="model-select">
+          <option value="openai">OpenAI</option>
+          <option value="deepseek">DeepSeek</option>
+        </select>
+      </label>
+      <input id="openai-key" type="text" placeholder="OpenAI API Key" />
+      <input id="deepseek-key" type="text" placeholder="DeepSeek API Key" />
+      <div class="modal-actions">
+        <button id="save-settings">保存</button>
+        <button id="clear-conversation">清除对话</button>
+        <button id="close-settings">关闭</button>
+      </div>
+    </div>
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,18 +1,42 @@
 const circleWrapper = document.getElementById('circle-wrapper');
+const circle = document.getElementById('breathing-circle');
 const chat = document.getElementById('chat');
 const messagesEl = document.getElementById('messages');
 const form = document.getElementById('input-form');
 const input = document.getElementById('message-input');
 
-let apiKey = '';
-let started = false;
+const settingsBtn = document.getElementById('settings-button');
+const settingsModal = document.getElementById('settings-modal');
+const modelSelect = document.getElementById('model-select');
+const openaiKeyInput = document.getElementById('openai-key');
+const deepseekKeyInput = document.getElementById('deepseek-key');
+const saveSettingsBtn = document.getElementById('save-settings');
+const closeSettingsBtn = document.getElementById('close-settings');
+const clearConversationBtn = document.getElementById('clear-conversation');
+
 let userLocation = '未知地点';
-let conversation = [];
+
+let settings = JSON.parse(localStorage.getItem('settings') || '{}');
+settings = Object.assign({ provider: 'openai', openaiKey: '', deepseekKey: '' }, settings);
+
+modelSelect.value = settings.provider;
+openaiKeyInput.value = settings.openaiKey;
+deepseekKeyInput.value = settings.deepseekKey;
+
+let conversation = JSON.parse(localStorage.getItem('conversation') || '[]');
 
 if (navigator.geolocation) {
   navigator.geolocation.getCurrentPosition(pos => {
     userLocation = `${pos.coords.latitude.toFixed(2)}, ${pos.coords.longitude.toFixed(2)}`;
   });
+}
+
+function saveConversation() {
+  localStorage.setItem('conversation', JSON.stringify(conversation));
+}
+
+function saveSettings() {
+  localStorage.setItem('settings', JSON.stringify(settings));
 }
 
 function addMessage(sender, text) {
@@ -23,14 +47,44 @@ function addMessage(sender, text) {
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
 
-circleWrapper.addEventListener('click', async () => {
-  if (started) return;
-  apiKey = prompt('请输入您的 OpenAI API 密钥');
-  if (!apiKey) return;
-  started = true;
-  chat.classList.remove('hidden');
-  await askFirstQuestion();
+conversation.filter(m => m.role !== 'system').forEach(m => {
+  addMessage(m.role === 'user' ? 'user' : 'assistant', m.content);
 });
+if (conversation.length > 0) {
+  chat.classList.remove('hidden');
+  circle.classList.add('breathing');
+}
+
+function openSettings() {
+  settingsModal.classList.remove('hidden');
+}
+
+function closeSettings() {
+  settingsModal.classList.add('hidden');
+}
+
+settingsBtn.addEventListener('click', openSettings);
+closeSettingsBtn.addEventListener('click', closeSettings);
+
+saveSettingsBtn.addEventListener('click', () => {
+  settings.provider = modelSelect.value;
+  settings.openaiKey = openaiKeyInput.value.trim();
+  settings.deepseekKey = deepseekKeyInput.value.trim();
+  saveSettings();
+  closeSettings();
+});
+
+clearConversationBtn.addEventListener('click', () => {
+  localStorage.removeItem('conversation');
+  conversation = [];
+  messagesEl.innerHTML = '';
+  chat.classList.add('hidden');
+  circle.classList.remove('breathing');
+});
+
+function getApiKey() {
+  return settings.provider === 'openai' ? settings.openaiKey : settings.deepseekKey;
+}
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -42,15 +96,69 @@ form.addEventListener('submit', async (e) => {
   const reply = await fetchAI(conversation);
   addMessage('assistant', reply);
   conversation.push({ role: 'assistant', content: reply });
+  saveConversation();
 });
+
+let clickTimer;
+circleWrapper.addEventListener('click', () => {
+  clearTimeout(clickTimer);
+  clickTimer = setTimeout(() => {
+    handleSingleClick();
+  }, 250);
+});
+
+circleWrapper.addEventListener('dblclick', () => {
+  clearTimeout(clickTimer);
+  handleDoubleClick();
+});
+
+async function handleSingleClick() {
+  circle.classList.add('shake');
+  setTimeout(() => circle.classList.remove('shake'), 500);
+  if (!getApiKey()) {
+    openSettings();
+    return;
+  }
+  if (conversation.length === 0) {
+    const time = new Date().toLocaleString();
+    conversation.push({
+      role: 'system',
+      content: '你是一个治愈系的智慧生命体，化身为一只呼吸的圆圈。你会用温柔、简短的中文与用户交谈。'
+    });
+    conversation.push({ role: 'user', content: `现在时间是${time}，我位于${userLocation}。` });
+  }
+  conversation.push({ role: 'user', content: '请预测我接下来可能会做什么。' });
+  const prediction = await fetchAI(conversation);
+  addMessage('assistant', prediction);
+  conversation.push({ role: 'assistant', content: prediction });
+  saveConversation();
+  chat.classList.remove('hidden');
+}
+
+async function handleDoubleClick() {
+  circle.classList.add('breathing');
+  if (!getApiKey()) {
+    openSettings();
+    return;
+  }
+  chat.classList.remove('hidden');
+  if (conversation.length === 0) {
+    await askFirstQuestion();
+  } else {
+    conversation.push({ role: 'user', content: '请再问我一个能够更了解我的问题。' });
+    const question = await fetchAI(conversation);
+    addMessage('assistant', question);
+    conversation.push({ role: 'assistant', content: question });
+    saveConversation();
+  }
+}
 
 async function askFirstQuestion() {
   const time = new Date().toLocaleString();
   conversation = [
     {
       role: 'system',
-      content:
-        '你是一个治愈系的智慧生命体，化身为一只呼吸的圆圈。你会用温柔、简短的中文与用户交谈。'
+      content: '你是一个治愈系的智慧生命体，化身为一只呼吸的圆圈。你会用温柔、简短的中文与用户交谈。'
     },
     {
       role: 'user',
@@ -60,17 +168,24 @@ async function askFirstQuestion() {
   const question = await fetchAI(conversation);
   addMessage('assistant', question);
   conversation.push({ role: 'assistant', content: question });
+  saveConversation();
 }
 
 async function fetchAI(messages) {
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+  const key = getApiKey();
+  const provider = settings.provider;
+  const url = provider === 'deepseek'
+    ? 'https://api.deepseek.com/v1/chat/completions'
+    : 'https://api.openai.com/v1/chat/completions';
+  const model = provider === 'deepseek' ? 'deepseek-chat' : 'gpt-3.5-turbo';
+  const res = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`
+      Authorization: `Bearer ${key}`
     },
     body: JSON.stringify({
-      model: 'gpt-3.5-turbo',
+      model,
       messages
     })
   });

--- a/style.css
+++ b/style.css
@@ -51,8 +51,19 @@ html, body {
   height: 100%;
   border-radius: 50%;
   background: conic-gradient(red, orange, yellow, green, cyan, blue, violet, red);
-  animation: breathe 4s ease-in-out infinite;
   box-shadow: 0 0 40px rgba(255, 255, 255, 0.6);
+}
+
+#breathing-circle.breathing {
+  animation: breathe 4s ease-in-out infinite;
+}
+
+#breathing-circle.shake {
+  animation: shake 0.5s;
+}
+
+#breathing-circle.breathing.shake {
+  animation: breathe 4s ease-in-out infinite, shake 0.5s;
 }
 
 @keyframes breathe {
@@ -63,6 +74,13 @@ html, body {
 @keyframes spin {
   from { transform: translate(-50%, -50%) rotate(0deg); }
   to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(4px, -4px); }
+  50% { transform: translate(-4px, 4px); }
+  75% { transform: translate(4px, 4px); }
 }
 
 #chat {
@@ -135,4 +153,46 @@ html, body {
 
 .hidden {
   display: none;
+}
+
+#settings-button {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  background: rgba(0, 200, 150, 0.6);
+  border: none;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#settings-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+#settings-modal .modal-content {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 260px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }


### PR DESCRIPTION
## Summary
- add model settings modal with OpenAI/DeepSeek API keys and clear option
- enable circle double-click for breathing questions and single-click prediction
- persist conversation in local storage and update documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9981f215c8328add629eb30a7db1c